### PR TITLE
Various fixes and corrections (listed in the description)

### DIFF
--- a/AdministrationExample/META-INF/MANIFEST.MF
+++ b/AdministrationExample/META-INF/MANIFEST.MF
@@ -5,10 +5,11 @@ Bundle-SymbolicName: AdministrationExample;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Bundle-Vendor: 
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-16
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: AdministrationExample
 Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.emf.ecore.xmi,
  org.emoflon.smartemf
 Export-Package: AdministrationExample,
  AdministrationExample.impl
+

--- a/AdministrationTransformRule/META-INF/MANIFEST.MF
+++ b/AdministrationTransformRule/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-SymbolicName: AdministrationTransformRule; singleton:=true
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.commons.logging;version="1.2.0",
  org.apache.log4j
-Bundle-RequiredExecutionEnvironment: JavaSE-16
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.emoflon.ibex.common,
  org.emoflon.ibex.gt,
  org.emoflon.ibex.patternmodel,

--- a/AdministrationTransformRule/src/AdministrationTransformRule/AdministrationValidator.java
+++ b/AdministrationTransformRule/src/AdministrationTransformRule/AdministrationValidator.java
@@ -9,7 +9,7 @@ public class AdministrationValidator extends AdministrationTransformRuleDemocles
 	public AdministrationValidator() {
 		
 		
-		String filePathUrl = workspacePath + "Hospital2Administration\\instances\\trg.xmi";
+		String filePathUrl = workspacePath + "Hospital2Administration/instances/trg.xmi";
 		
 		loadModel(URI.createFileURI(filePathUrl));
 		

--- a/Hospital2Administration/META-INF/MANIFEST.MF
+++ b/Hospital2Administration/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Localization: plugin
 Bundle-SymbolicName: Hospital2Administration;singleton:=true
 Automatic-Module-Name: Hospital2Administration
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-16
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.emoflon.ibex.tgg.run.hospital2administration.config,
  Hospital2Administration,
  Hospital2Administration.impl

--- a/Hospital2AdministrationSolutions/META-INF/MANIFEST.MF
+++ b/Hospital2AdministrationSolutions/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Localization: plugin
 Bundle-SymbolicName: Hospital2AdministrationSolutions;singleton:=true
 Automatic-Module-Name: Hospital2AdministrationSolutions
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-16
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.emoflon.ibex.tgg.run.hospital2administrationsolutions.config,
  Hospital2AdministrationSolutions,
  Hospital2AdministrationSolutions.impl
@@ -30,3 +30,4 @@ Require-Bundle: AdministrationExample;visibility:=reexport,
  org.eclipse.emf.ecore;visibility:=reexport,
  org.emoflon.ibex.tgg.runtime.hipe,
  org.emoflon.smartemf
+

--- a/HospitalExample/META-INF/MANIFEST.MF
+++ b/HospitalExample/META-INF/MANIFEST.MF
@@ -5,10 +5,11 @@ Bundle-SymbolicName: HospitalExample;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Bundle-Vendor: 
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-16
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: HospitalExample
 Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.emf.ecore.xmi,
  org.emoflon.smartemf
 Export-Package: HospitalExample,
  HospitalExample.impl
+

--- a/HospitalTransformRules/META-INF/MANIFEST.MF
+++ b/HospitalTransformRules/META-INF/MANIFEST.MF
@@ -4,13 +4,15 @@ Bundle-ManifestVersion: 2
 Bundle-Version: 0.0.1
 Bundle-SymbolicName: HospitalTransformRules;singleton:=true
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-16
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.emoflon.ibex.common,
  org.emoflon.ibex.gt,
  org.emoflon.ibex.patternmodel,
  org.emoflon.ibex.gt.democles,
  org.emoflon.ibex.gt.hipe,
- HospitalExample;bundle-version="0.0.1"
+ HospitalExample;bundle-version="0.0.1",
+ org.eclipse.emf.ecore
 Export-Package: HospitalTransformRules.api,
  HospitalTransformRules.api.matches,
  HospitalTransformRules.api.rules
+

--- a/HospitalTransformRules/hospital.xmi
+++ b/HospitalTransformRules/hospital.xmi
@@ -1,68 +1,66 @@
-<?xml version="1.0" encoding="ASCII"?>
-<HospitalExample:Hospital xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:HospitalExample="platform:/resource/HospitalExample/model/HospitalExample.ecore">
-  <reception/>
-  <staff xsi:type="HospitalExample:Doctor" staffID="2" works="2" name="Eliza Clark" caresfor="//@department.3/@rooms.2/@lies.0 //@department.3/@rooms.2/@lies.2" patientCapacity="16"/>
-  <staff xsi:type="HospitalExample:Doctor" staffID="3" works="4" name="Bob Reed" caresfor="//@department.1/@rooms.0/@lies.0 //@department.3/@rooms.2/@lies.1 //@department.1/@rooms.1/@lies.0" patientCapacity="16"/>
-  <staff xsi:type="HospitalExample:Doctor" staffID="4" works="3" name="Bob Williams" caresfor="//@department.3/@rooms.3/@lies.0 //@department.0/@rooms.1/@lies.0 //@department.2/@rooms.1/@lies.0" patientCapacity="16"/>
-  <staff xsi:type="HospitalExample:Doctor" staffID="5" works="5" name="Allan Stafford" caresfor="//@department.3/@rooms.0/@lies.0 //@department.2/@rooms.3/@lies.0 //@department.3/@rooms.1/@lies.0" patientCapacity="16"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="6" works="5" name="Robert Stafford" responsible="//@department.3/@rooms.3"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="7" works="2" name="Stefanie Jones" responsible="//@department.0/@rooms.1"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="8" works="4" name="Robert Greenwood" responsible="//@department.2/@rooms.3"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="9" works="3" name="James Jones" responsible="//@department.1/@rooms.1"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="10" works="5" name="Abigail Ramirez" responsible="//@department.3/@rooms.1"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="11" works="3" name="James Clark" responsible="//@department.1/@rooms.3"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="12" works="3" name="George Martinez" responsible="//@department.1/@rooms.2"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="13" works="2" name="Eliza Lewis" responsible="//@department.0/@rooms.2"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="14" works="4" name="Ron Clark" responsible="//@department.2/@rooms.0"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="15" works="2" name="Chloe Rivera" responsible="//@department.0/@rooms.3"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="16" works="3" name="Eliza Greenwood" responsible="//@department.1/@rooms.0"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="17" works="5" name="Martin Taylor" responsible="//@department.3/@rooms.0"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="18" works="5" name="Sven Hall" responsible="//@department.3/@rooms.2"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="19" works="4" name="James Green" responsible="//@department.2/@rooms.1"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="20" works="4" name="Adam Jones" responsible="//@department.2/@rooms.2"/>
-  <staff xsi:type="HospitalExample:Nurse" staffID="21" works="2" name="Martin Jupiter" responsible="//@department.0/@rooms.0"/>
-  <department dID="2" staff="//@staff.0 //@staff.5 //@staff.11 //@staff.13 //@staff.19" maxRoomCount="4">
-    <rooms capacity="4" level="STRONG" nurses="//@staff.19"/>
-    <rooms capacity="4" nurses="//@staff.5">
-      <lies patientID="3" name="Allan Martinez" doctor="//@staff.2"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<HospitalExample:Hospital xmlns:HospitalExample="platform:/resource/HospitalExample/model/HospitalExample.ecore" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmi:version="2.0">
+  <reception />
+  <staff xsi:type="HospitalExample:Doctor" staffID="2" name="Eliza Clark" patientCapacity="16" works="//@department.0" caresfor="//@department.2/@rooms.0/@lies.0 //@department.1/@rooms.3/@lies.0" />
+  <staff xsi:type="HospitalExample:Doctor" staffID="3" name="Bob Reed" patientCapacity="16" works="//@department.1" caresfor="//@department.3/@rooms.2/@lies.0 //@department.0/@rooms.0/@lies.0 //@department.3/@rooms.1/@lies.1 //@department.2/@rooms.1/@lies.1" />
+  <staff xsi:type="HospitalExample:Doctor" staffID="4" name="Bob Williams" patientCapacity="16" works="//@department.3" caresfor="//@department.3/@rooms.1/@lies.0 //@department.2/@rooms.3/@lies.0 //@department.2/@rooms.1/@lies.0 //@department.3/@rooms.2/@lies.2" />
+  <staff xsi:type="HospitalExample:Doctor" staffID="5" name="Allan Stafford" patientCapacity="16" works="//@department.2" caresfor="//@department.3/@rooms.2/@lies.1" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="6" name="Robert Stafford" works="//@department.0" responsible="//@department.0/@rooms.1" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="7" name="Stefanie Jones" works="//@department.1" responsible="//@department.1/@rooms.2" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="8" name="Robert Greenwood" works="//@department.2" responsible="//@department.2/@rooms.2" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="9" name="James Jones" works="//@department.0" responsible="//@department.0/@rooms.2" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="10" name="Abigail Ramirez" works="//@department.3" responsible="//@department.3/@rooms.0" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="11" name="James Clark" works="//@department.3" responsible="//@department.3/@rooms.2" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="12" name="George Martinez" works="//@department.2" responsible="//@department.2/@rooms.1" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="13" name="Eliza Lewis" works="//@department.3" responsible="//@department.3/@rooms.1" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="14" name="Ron Clark" works="//@department.0" responsible="//@department.0/@rooms.0" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="15" name="Chloe Rivera" works="//@department.1" responsible="//@department.1/@rooms.0" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="16" name="Eliza Greenwood" works="//@department.2" responsible="//@department.2/@rooms.3" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="17" name="Martin Taylor" works="//@department.1" responsible="//@department.1/@rooms.3" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="18" name="Sven Hall" works="//@department.2" responsible="//@department.2/@rooms.0" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="19" name="James Green" works="//@department.3" responsible="//@department.3/@rooms.3" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="20" name="Adam Jones" works="//@department.0" responsible="//@department.0/@rooms.3" />
+  <staff xsi:type="HospitalExample:Nurse" staffID="21" name="Martin Jupiter" works="//@department.1" responsible="//@department.1/@rooms.1" />
+  <department staff="//@staff.0 //@staff.4 //@staff.7 //@staff.12 //@staff.18" dID="2" maxRoomCount="4">
+    <rooms nurses="//@staff.12" capacity="4" level="STRONG">
+      <lies doctor="//@staff.1" patientID="8" name="Robert King" level="PENDING" />
     </rooms>
-    <rooms capacity="4" nurses="//@staff.11"/>
-    <rooms capacity="4" level="MEDIUM" nurses="//@staff.13"/>
+    <rooms nurses="//@staff.4" capacity="4" level="WEAK" />
+    <rooms nurses="//@staff.7" capacity="4" level="WEAK" />
+    <rooms nurses="//@staff.18" capacity="4" level="MEDIUM" />
   </department>
-  <department dID="3" staff="//@staff.2 //@staff.7 //@staff.9 //@staff.10 //@staff.14" maxRoomCount="4">
-    <rooms capacity="4" nurses="//@staff.14">
-      <lies patientID="8" name="Robert King" doctor="//@staff.1"/>
-    </rooms>
-    <rooms capacity="4" nurses="//@staff.7">
-      <lies patientID="10" name="Misha King" doctor="//@staff.1"/>
-    </rooms>
-    <rooms capacity="4" level="MEDIUM" nurses="//@staff.10"/>
-    <rooms capacity="4" level="MEDIUM" nurses="//@staff.9"/>
-  </department>
-  <department dID="4" staff="//@staff.1 //@staff.6 //@staff.12 //@staff.17 //@staff.18" maxRoomCount="4">
-    <rooms capacity="4" level="MEDIUM" nurses="//@staff.12"/>
-    <rooms capacity="4" level="MEDIUM" nurses="//@staff.17">
-      <lies patientID="12" name="Lauren Hall" doctor="//@staff.2"/>
-    </rooms>
-    <rooms capacity="4" nurses="//@staff.18"/>
-    <rooms capacity="4" nurses="//@staff.6">
-      <lies patientID="6" name="Alex Brown" doctor="//@staff.3"/>
+  <department staff="//@staff.1 //@staff.5 //@staff.13 //@staff.15 //@staff.19" dID="3" maxRoomCount="4">
+    <rooms nurses="//@staff.13" capacity="4" level="MEDIUM" />
+    <rooms nurses="//@staff.19" capacity="4" level="MEDIUM" />
+    <rooms nurses="//@staff.5" capacity="4" level="WEAK" />
+    <rooms nurses="//@staff.15" capacity="4" level="WEAK">
+      <lies doctor="//@staff.0" patientID="3" name="Allan Martinez" level="PENDING" />
     </rooms>
   </department>
-  <department dID="5" staff="//@staff.3 //@staff.4 //@staff.8 //@staff.15 //@staff.16" maxRoomCount="4">
-    <rooms capacity="4" level="STRONG" nurses="//@staff.15">
-      <lies patientID="7" name="Stefanie Rivera" doctor="//@staff.3"/>
+  <department staff="//@staff.3 //@staff.6 //@staff.10 //@staff.14 //@staff.16" dID="4" maxRoomCount="4">
+    <rooms nurses="//@staff.16" capacity="4" level="STRONG">
+      <lies doctor="//@staff.0" patientID="7" name="Stefanie Rivera" level="PENDING" />
     </rooms>
-    <rooms capacity="4" level="STRONG" nurses="//@staff.8">
-      <lies patientID="5" name="John Lewis" doctor="//@staff.3"/>
+    <rooms nurses="//@staff.10" capacity="4" level="STRONG">
+      <lies doctor="//@staff.2" patientID="2" name="Bob More" level="PENDING" />
+      <lies doctor="//@staff.1" patientID="12" name="Lauren Hall" level="PENDING" />
     </rooms>
-    <rooms capacity="4" level="STRONG" nurses="//@staff.16">
-      <lies patientID="9" name="Martin King" doctor="//@staff.0"/>
-      <lies patientID="2" name="Bob More" doctor="//@staff.1"/>
-      <lies patientID="11" name="James Williams" doctor="//@staff.0"/>
+    <rooms nurses="//@staff.6" capacity="4" level="STRONG" />
+    <rooms nurses="//@staff.14" capacity="4" level="MEDIUM">
+      <lies doctor="//@staff.2" patientID="5" name="John Lewis" level="PENDING" />
     </rooms>
-    <rooms capacity="4" level="MEDIUM" nurses="//@staff.4">
-      <lies patientID="4" name="Steven Clark" doctor="//@staff.2"/>
+  </department>
+  <department staff="//@staff.2 //@staff.8 //@staff.9 //@staff.11 //@staff.17" dID="5" maxRoomCount="4">
+    <rooms nurses="//@staff.8" capacity="4" level="WEAK" />
+    <rooms nurses="//@staff.11" capacity="4" level="WEAK">
+      <lies doctor="//@staff.2" patientID="6" name="Alex Brown" level="PENDING" />
+      <lies doctor="//@staff.1" patientID="9" name="Martin King" level="PENDING" />
     </rooms>
+    <rooms nurses="//@staff.9" capacity="4" level="MEDIUM">
+      <lies doctor="//@staff.1" patientID="4" name="Steven Clark" level="PENDING" />
+      <lies doctor="//@staff.3" patientID="10" name="Misha King" level="PENDING" />
+      <lies doctor="//@staff.2" patientID="11" name="James Williams" level="PENDING" />
+    </rooms>
+    <rooms nurses="//@staff.17" capacity="4" level="MEDIUM" />
   </department>
 </HospitalExample:Hospital>

--- a/HospitalTransformRules/src/HospitalTransformRules/HospitalValidator.java
+++ b/HospitalTransformRules/src/HospitalTransformRules/HospitalValidator.java
@@ -5,8 +5,10 @@ import HospitalTransformRules.api.HospitalTransformRulesHiPEApp;
 
 public class HospitalValidator extends HospitalTransformRulesHiPEApp  {
 	
+	public static String hospitalFilePath = "hospital.xmi";
+	
 	public HospitalValidator() {
-		createModel(URI.createURI("hospital.xmi"));
+		createModel(URI.createURI(hospitalFilePath));
 	}	
 
 }

--- a/tutorial-doc/.gitignore
+++ b/tutorial-doc/.gitignore
@@ -229,3 +229,6 @@ TSWLatexianTemp*
 TUDthesis.pdf
 logo/tud_logo.pdf
 LaTeX2e+Proceedings+Templates+download/
+
+emoflon-tutorial.pdf
+

--- a/tutorial-doc/chapters/gt.tex
+++ b/tutorial-doc/chapters/gt.tex
@@ -697,45 +697,33 @@ Let us inspect HospitalRules.java a bit more closely since there is much of inte
 
 12\hspace{1.5cm}\textcolor{Tan}{hospitalrules}.validateHospital();
 
-13\hspace{1cm}\textcolor{Purple}{try} \{
+13\hspace{1.5cm}persistModel(HospitalValidator.hospitalFilePath, \textcolor{Tan}{hospitalrules}\textcolor{blue}{api});
 
-14\hspace{1.5cm}\textcolor{Tan}{hospitalrules}.\textcolor{blue}{api}.getModel().getResources().get(0).save(null); 
+14\hspace{1.5cm}\textcolor{Tan}{hospitalrules}.\textcolor{blue}{api}.terminate();
 
-15\hspace{1cm}\}
+15\hspace{1.0cm}\}
 
-16\hspace{1cm}\textcolor{Purple}{catch} (IOException e) \{
+16\hspace{1.0cm}\textcolor{Purple}{public void} createHospital() \{
 
-17\hspace{1.5cm}// TODO Auto-generated catch block
+17\hspace{1.5cm}\textcolor{blue}{api}.hospital().apply();
 
-18\hspace{1.5cm}\textcolor{Tan}{e}.printStackTrace();
+18\hspace{1.5cm}\textcolor{blue}{api}.reception().apply();
 
-19\hspace{1cm}\}
+19\hspace{1.5cm}\textcolor{Purple}{for}(\textcolor{Purple}{int} \textcolor{Tan}{i}=0; \textcolor{Tan}{i}<4; \textcolor{Tan}{i}++) \{
 
-20\hspace{1cm}\textcolor{Tan}{hospitalrules}.\textcolor{blue}{api}.terminate();
+20\hspace{2.0cm}\textcolor{blue}{api}.department(i+2, 4).apply();
 
-21\hspace{0.5cm}\}
+21\hspace{1.5cm}\}
 
-22\hspace{0.5cm}\textcolor{Purple}{public void} createHospital() \{
+22\hspace{1.5cm}\textcolor{Purple}{for}(\textcolor{Purple}{int} \textcolor{Tan}{i}=0; \textcolor{Tan}{i}<16; \textcolor{Tan}{i}++) \{
 
-23\hspace{1cm}\textcolor{blue}{api}.hospital().apply();
+23\hspace{2.0cm}\textcolor{blue}{api}.room(4, Carelevel.get(\textcolor{blue}{rnd}.nextInt(3))).apply();
 
-24\hspace{1cm}\textcolor{blue}{api}.reception().apply();
+24\hspace{1.5cm}\} 
 
-25\hspace{1cm}\textcolor{Purple}{for}(\textcolor{Purple}{int} \textcolor{Tan}{i}=0; \textcolor{Tan}{i}<4; \textcolor{Tan}{i}++) \{
+25\hspace{1.5cm}…
 
-26\hspace{1.5cm}\textcolor{blue}{api}.department(i+2, 4).apply();
-
-27\hspace{1cm}\}
-
-28\hspace{1cm}\textcolor{Purple}{for}(\textcolor{Purple}{int} \textcolor{Tan}{i}=0; \textcolor{Tan}{i}<16; \textcolor{Tan}{i}++) \{
-
-29\hspace{1.5cm}\textcolor{blue}{api}.room(4, Carelevel.get(\textcolor{blue}{rnd}.nextInt(3))).apply();
-
-30\hspace{1cm}\} 
-
-\hspace{0.7cm}…
-
-\hspace{0.7cm}\}
+26\hspace{1.0cm}\}
 
 }
 
@@ -748,7 +736,7 @@ The API command is used to access and apply our rules and patterns.\newline
 
 \textbf{Saving the project:}
 
-Another important thing to note is happening on \textbf{line 14} where we save our hospital model. It is important to note that the hospital instance we have initialized in the \textsf{HospitalValidator} will \textbf{not be stored} anywhere. If we want to keep it for usage in the future, we have to \textbf{save it with a separate command} as we are doing it in line 14.\newline The URI \textsf{hospital.xmi} is saved in the project folder of the \textsf{HospitalTransformRules} project.\newline
+Another important thing to note is happening on \textbf{line 13} where we save our hospital model. The method \textsf{persistModel(...)} is a utility method that can be found at the end of this source file. It is important to note that the hospital instance we have initialized in the \textsf{HospitalValidator} will \textbf{not be stored} anywhere. If we want to keep it for usage in the future, we have to \textbf{save it with a separate command} as we are doing it in line 13.\newline The URI \textsf{hospital.xmi} is saved in the project folder of the \textsf{HospitalTransformRules} project.\newline
 
 \textbf{Rule application:}
 
@@ -789,26 +777,19 @@ System.\textcolor{blue}{out}.println(\textcolor{Tan}{countPatientsInHospital} + 
 You can run the java application by \textbf{right-clicking} on the \textsf{HospitalRule.java} and selecting the \textsf{Run as Java Application} option. If you look at the output in the console, and it should look like this:\newline
 
 {\setstretch{1.2}
-
-\textsf{10 Patients are in the hospital right now}
-
-\textsf{10 Patients are in a room}
-
 \textsf{One instance of a hospital has been created}
+
+\textsf{One instance of a reception has been created}
 
 \textsf{At least one department instance has been created}
 
 \textsf{16 nurses are in the hospital right now and 16 nurses are busy}
 
-\textsf{At least one doctor is in the hospital}
-
-\textsf{4 doctors are in the hospital right now and 4 doctors are busy}
+\textsf{4 doctors are in the hospital right now and 3 doctors are busy}
 
 \textsf{At least one patient is in the hospital}
 
-\textsf{The hospital consists of at least one room}
-
-\textsf{10 Patients are in the hospital right now and 10 patients are in a room}\newline
+\textsf{11 Patients are in the hospital right now and 11 patients are in a room}\newline
 
 }
 


### PR DESCRIPTION
This pull request fixes various errors and includes some corrections.
- Closes #4 and closes #20: Removes the hard-coded Windows-specific file path to also allow the example to run on Linux and macOS (commit: d374cc4073ddf6c0dfaca7bccc1fbf044100e0cb).
- Closes #17: Introduces a utility method to successfully save XMI model instances for the HospitalRules example (commit: 10a20eeae36670884f0bf7c17db737d7710ba018).
- Closes #18: Regarding the previous point, this reflects the code changes in the documentation and also cleans up the code formatting in this snippet (commit: 010c3cc85e6b6fea2533a8bc1042369933037dab).
- Closes #16: Updates all `MANIFEST.MF` files to include the newest versions of the eMoflon::IBeX MANIFEST writer (commit: 250faae8c31e769e3ecce4eb54053942d93bc789).